### PR TITLE
Use AppName for page title instead of "Prelaunch App"

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -66,12 +66,12 @@ router.get('/signup/confirm*', function(req, res, next) {
   function(err){
     if(err) {
       res.render('index', {
-        title: 'Prelaunch App',
+        title: secrets.appName,
         error: "This confirmation token is invalid or has expired."
       });
     } else {
       res.render('index', {
-        title: 'Prelaunch App',
+        title: secrets.appName,
         confirmed: true
       });
     }


### PR DESCRIPTION
Use AppName specified in secrets instead of "Prelaunch App" for page title.
