### PR TITLE
bugfix. Fix ENV variable name, it should be MONGODB_URI to match Heroku config

### DIFF
--- a/server/config/secrets.js
+++ b/server/config/secrets.js
@@ -1,7 +1,7 @@
 module.exports = {
   env: process.env.NODE_ENV || 'development',
   appName: process.env.APP_NAME || 'Node Prelaunch',
-  db: process.env.MONGODB || process.env.MONGOLAB_URI || process.env.MONGOHQ_URL || 'mongodb://localhost:27017/node-prelaunch',
+  db: process.env.MONGODB_URI || process.env.MONGOLAB_URI || process.env.MONGOHQ_URL || 'mongodb://localhost:27017/node-prelaunch',
   mailgun: {
     domain: process.env.MAILGUN_DOMAIN || '',
     api: process.env.MAILGUN_API_KEY || '',


### PR DESCRIPTION
The environment variable name is not coherent with the Heroku app config making the DB failed to connect